### PR TITLE
Exposes a getMatches() function for getting matches paths only

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,15 +10,19 @@
 var utils = require('./utils');
 
 function globObject(patterns, obj, opts) {
-  patterns = arrayify(patterns).map(toSlashes);
-  var keys = utils.stringify(obj, '/');
-  var matches = utils.mm(keys, patterns, opts);
+  var matches = getMatches(patterns, obj, opts);
 
   return matches.reduce(function(acc, path) {
     var key = toDots(path);
     utils.set(acc, key, utils.get(obj, key));
     return acc;
   }, {});
+}
+
+function getMatches(patterns, obj, opts) {
+  patterns = arrayify(patterns).map(toSlashes);
+  var keys = utils.stringify(obj, '/');
+  return utils.mm(keys, patterns, opts);
 }
 
 function toSlashes(key) {
@@ -38,3 +42,5 @@ function arrayify(val) {
  */
 
 module.exports = globObject;
+module.exports.globObject = globObject;
+module.exports.getMatches = getMatches;

--- a/test.js
+++ b/test.js
@@ -11,6 +11,7 @@ require('mocha');
 require('should');
 var assert = require('assert');
 var globObject = require('./');
+var getMatches = globObject.getMatches;
 
 var fixture = {
   a: {
@@ -43,3 +44,22 @@ describe('globObject', function() {
     assert.deepEqual(globObject('a.**.g', fixture), {a: {b: {g: 'h', l: {g: 'k'}}}});
   });
 });
+
+describe('getMatches', function() {
+  it('should match properties using wildcards:', function() {
+    assert.deepEqual(getMatches('a.*', fixture), ['a/b', 'a/i']);
+  });
+
+  it('should match properties using braces:', function() {
+    assert.deepEqual(getMatches('*.{b,i}', fixture), ['a/b', 'a/i']);
+    assert.deepEqual(getMatches('a.*.{c,e}', fixture), ['a/b/c', 'a/b/e']);
+  });
+
+  it('should match a nested property using a wildcard:', function() {
+    assert.deepEqual(getMatches('a.*.g', fixture), ['a/b/g']);
+  });
+
+  it('should match deep properties using globstars', function() {
+    assert.deepEqual(getMatches('a.**.g', fixture), ['a/b/g', 'a/b/l/g']);
+  });
+})


### PR DESCRIPTION
Hey there.

This module has exactly the functionality I am currently looking for, expect hidden away from public consumption.

I need to get all object paths matching a glob string, and not the resulting object itself. The particular case is modifying [`immutable`](https://facebook.github.io/immutable-js/docs/#/Map/setIn) objects.

An example would look like:

```js
import { getMatches } from 'glob-object'

const obj = {
  dontCacheMe: 123,
  tracks: {
    guitar: { type: 'instrument' },
    drums: { type: 'instrument' },
    reverb: { type: 'send effect' },
  },
}

const cachedPaths = getMatches('tracks.*' obj)
const cachedKeyPaths = cachedPaths.map(path => path.split('/'))
// Use key paths to modify an immutable object
```

I wrote tests to verify it worked. If you want to merge this PR I can add some docs and examples!

Cheers